### PR TITLE
feat: Fix createComment resolver 반환형태 변경 & computed fields 추가

### DIFF
--- a/src/apollo/comments/comments.resolvers.js
+++ b/src/apollo/comments/comments.resolvers.js
@@ -1,0 +1,12 @@
+/**
+ * 생성일 : 22.02.19
+ * 수정일 : ------
+ */
+
+import client from '../../client';
+
+export default {
+    Comment: {
+        user: ({ userId }) => client.user.findUnique({ where: { id: userId } }),
+    }
+}

--- a/src/apollo/comments/createComment/createComment.resolvers.js
+++ b/src/apollo/comments/createComment/createComment.resolvers.js
@@ -1,6 +1,6 @@
 /**
  * 생성일 : 22.02.07
- * 수정일 : ------
+ * 수정일 : 22.02.19
  */
 
 import client from '../../../client';
@@ -20,7 +20,7 @@ export default {
                     });
                     if (!isExistPost) throw new Error("존재하지 않는 게시글입니다.");
 
-                    await client.comment.create({
+                    const createdComment = await client.comment.create({
                         data: {
                             comment,
                             post: {
@@ -33,17 +33,14 @@ export default {
                                     id: loggedInUser.id
                                 }
                             }
+                        },
+                        include: {
+                            user: true
                         }
                     });
-
-                    return {
-                        ok: true
-                    }
-                } catch (error) {
-                    return {
-                        ok: false,
-                        error: error.message
-                    }
+                    return createdComment;
+                } catch {
+                    return null
                 }
             }
         )

--- a/src/apollo/comments/createComment/createComment.typeDefs.js
+++ b/src/apollo/comments/createComment/createComment.typeDefs.js
@@ -1,12 +1,12 @@
 /**
  * 생성일 : 22.02.07
- * 수정일 : ------
+ * 수정일 : 22.02.19
  */
 
 import { gql } from 'apollo-server';
 
 export default gql`
     type Mutation{
-        createComment(postId:Int!,comment:String!):MutationResults!
+        createComment(postId:Int!,comment:String!):Comment
     }
 `

--- a/src/apollo/posts/posts.resolvers.js
+++ b/src/apollo/posts/posts.resolvers.js
@@ -1,6 +1,6 @@
 /**
  * 생성일 : 22.02.07
- * 수정일 : 22.02.18
+ * 수정일 : 22.02.19
  */
 
 import client from '../../client';
@@ -22,6 +22,9 @@ export default {
             return Boolean(checkIsLiked);
         },
         commentCount: ({ id }) => client.comment.count({ where: { postId: id } }),
-        comments: ({ id }) => client.comment.findMany({ where: { postId: id } }),
+        comments: ({ id }) => client.comment.findMany({
+            where: { postId: id },
+            include: { user: true }
+        }),
     }
 }

--- a/src/apollo/posts/seePost/seePost.resolvers.js
+++ b/src/apollo/posts/seePost/seePost.resolvers.js
@@ -1,6 +1,6 @@
 /**
  * 생성일 : 22.02.07
- * 수정일 : 22.02.18
+ * 수정일 : 22.02.19
  */
 
 import client from '../../../client'
@@ -16,7 +16,7 @@ export default {
                 include: {
                     frontends: true,
                     backends: true,
-                    apps: true
+                    apps: true,
                 },
             })
 

--- a/src/apollo/users/users.typeDefs.js
+++ b/src/apollo/users/users.typeDefs.js
@@ -1,6 +1,6 @@
 /**
  * 생성일 : 22.02.07
- * 수정일 : 22.02.17
+ * 수정일 : 22.02.19
  */
 
 import { gql } from 'apollo-server';
@@ -12,7 +12,6 @@ export default gql`
         socialLogin:String
         name:String!
         email:String!
-        password:String!
         createdAt:String!
         likes:[Like]
         posts:[Post]


### PR DESCRIPTION
1. 무엇을? : createComment resolver의 반환형태를 Comment로 변경함, seePost에서 활용하기 위한 comment관련 computed fields 추가
2. 왜? : 프론트에서 mutation 처리 후 응답으로 comment정보를 받아 cache에 반영하기 위함