### PR TITLE
feat: Add checkExistUser

### DIFF
--- a/src/apollo/users/checkExistUser/checkExistUser.resolvers.js
+++ b/src/apollo/users/checkExistUser/checkExistUser.resolvers.js
@@ -1,0 +1,30 @@
+/**
+ * 생성일 : 22.03.06
+ * 수정일 : ------
+ */
+
+import client from '../../../client'
+
+export default {
+    Mutation: {
+        checkExistUser: async (_, { name, email }) => {
+            try {
+                // Unique 항목인 요소들에 대해 유일한지 검사
+                const isUnique = await client.user.count({
+                    where: {
+                        OR: [{ name }, { email }]
+                    }
+                })
+                if (isUnique) throw new Error("이미 존재하는 아이디 혹은 이메일입니다.")
+                return {
+                    ok: true
+                }
+            } catch (error) {
+                return {
+                    ok: false,
+                    error: error.message
+                }
+            }
+        }
+    }
+}

--- a/src/apollo/users/checkExistUser/checkExistUser.typeDefs.js
+++ b/src/apollo/users/checkExistUser/checkExistUser.typeDefs.js
@@ -1,0 +1,12 @@
+/**
+ * 생성일 : 22.03.06
+ * 수정일 : ------
+ */
+
+import { gql } from 'apollo-server';
+
+export default gql`
+    type Mutation{
+        checkExistUser(name:String!,email:String!):MutationResults!
+    }
+`

--- a/src/express/controller/socialLoginController.js
+++ b/src/express/controller/socialLoginController.js
@@ -148,7 +148,7 @@ export const kakaoLogin = async (req, res) => {
     const config = {
         grant_type: "authorization_code",
         client_id: process.env.KAKAO_REST_API_KEY,
-        redirect_uri: process.env.NODE_ENV === "production" ? process.env.SOCIAL_KAKAO_CODE_REDIRECT_PRO : process.env.SOCIAL_KAKAO_CODE_REDIRECT_DEV,
+        redirect_uri: process.env.SOCIAL_KAKAO_CODE_REDIRECT,
         code
     }
 


### PR DESCRIPTION
1. 무엇을? : 회원가입 이전에 동일 닉네임,이메일 존재여부를 확인해주는 resolver생성
2. 왜? : 유일성 체크는 createUser에서 처리해도 되긴 하나 이메일 인증 로직 상 확인코드 전송 전에 미리 유일성 체크를 해야하므로 따로 확인 resolver를 생성한 것이다